### PR TITLE
pin numpy to 1.26.0 to avoid numpy 2.0 deprecation errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ chromadb==0.4.24
 langchain
 sentence-transformers
 protobuf==3.20.*
-numpy>=1.25.0
+numpy==1.26.0
 pysqlite3-binary ; platform_system == "Windows"


### PR DESCRIPTION
updated dev into main. numpy version in requirements.txt